### PR TITLE
Rudimentary masking support

### DIFF
--- a/probtorch/stochastic.py
+++ b/probtorch/stochastic.py
@@ -317,7 +317,6 @@ class Trace(MutableMapping):
                                   sample_dim,
                                   batch_dim)
                 if batch_dim is not None and node.mask is not None:
-                    #view_size = (-1,) + (1,) * (log_p.dim() - batch_dim - 1)
                     log_p = log_p * node.mask
                 log_prob = log_prob + log_p
         return log_prob


### PR DESCRIPTION
This pull requests adds a `mask` attribute to the `Trace` data structure, which by default is set to `None`. When set, the `mask` specifies a `Variable` of size `(batch_size,)`, which is used to mask out batch items when calling `Trace.log_joint`. This can be used to implement control flow. 

Note that we don't check *anything* at this time. In theory `mask` should contain only 0 and 1 values, but in practice you can set this value to anything. As such, the name `mask` is more a usage hint than a type specification.  