### PR TITLE
More graceful handling of missing keys in a Trace

### DIFF
--- a/probtorch/stochastic.py
+++ b/probtorch/stochastic.py
@@ -130,7 +130,7 @@ class Trace(MutableMapping):
         self._counters = {}
 
     def __getitem__(self, name):
-        return self._nodes[name]
+        return self._nodes.get(name, None)
 
     def __setitem__(self, name, node):
         if not isinstance(node, Stochastic):


### PR DESCRIPTION
This commit changes the behavior of `Trace` when attempting to get a non-existent variable name. Rather than throwing a `KeyError`, like a dictionary, we now simply return `None`. 

The reason for this change is to support the following style of writing models:
```python
def binary_cross_entropy(x_mean, x, EPS=1e-9):
    return - (torch.log(x_mean + EPS) * x + 
              torch.log(1 - x_mean + EPS) * (1 - x)).sum(-1)

class Decoder(nn.Module):
    def __init__(self, num_pixels=784, num_hidden=50, num_digits=10, num_style=2):
        super(self.__class__, self).__init__()
        self.num_digits = num_digits
        self.h = nn.Sequential(
                   nn.Linear(num_style + num_digits, num_hidden),
                   nn.ReLU())
        self.x_mean = nn.Sequential(
                        nn.Linear(num_hidden, num_pixels),
                        nn.Sigmoid())

    def forward(self, x, q=None):
        if q is None:
            q = probtorch.Trace()
        p = probtorch.Trace()
        y = p.concrete(Variable(torch.zeros(x.size(0), self.num_digits)), 0.66,
                       value=q['y'], name='y')
        z = p.normal(0.0, 1.0, value=q['z'], name='z')
        h = self.h(torch.cat([y, z], -1))
        p.loss(binary_cross_entropy, self.x_mean(h), x, name='x')
        return p
```

In the model above, we initialize `q` to an empty trace when not provided. This empty trace now returns `None` when attempting to retrieve `q['y']` and `q['z']`, causing the decoder to sample from the generative model instead of observing the previously sampled values.