### PR TITLE
Minor touches

### DIFF
--- a/probtorch/util.py
+++ b/probtorch/util.py
@@ -16,7 +16,8 @@ __all__ = ['broadcast_size',
 def expand_inputs(f):
     """Decorator that expands all input tensors to add a sample dimensions"""
     @wraps(f)
-    def g(*args, num_samples=None, **kwargs):
+    def g(*args, **kwargs):
+        num_samples = kwargs.pop('num_samples', None)
         if num_samples is not None:
             new_args = []
             new_kwargs = {}

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import io
 import os
 import sys


### PR DESCRIPTION
Mainly for python 2.7 compatibility, I think. Will update this pull request if I find anything else (so far, I've run the tests in `/tests`, but haven't tried any real examples).

An alternative for the explicit encoding in `setup.py` would be to simply remove the unicode character (there is an `…` character, I think this is all). I'm also not certain whether this is the "best" encoding; I selected it only because the file already contained a reference to utf-8.