### PR TITLE
bring back sample_dim in log_joint

### DIFF
--- a/probtorch/objectives/marginal.py
+++ b/probtorch/objectives/marginal.py
@@ -80,7 +80,7 @@ def elbo(q, p, sample_dim=None, batch_dim=None, alpha=0.1, beta=(1.0, 1.0, 1.0, 
 
 
 def kl(q, p, sample_dim=None, batch_dim=None, log_weights=None, beta=(1.0, 1.0, 1.0, 1.0, 1.0),
-         size_average=True, reduce=True, bias=None):
+       size_average=True, reduce=True, bias=None):
     r"""
     Computes a Monte Carlo estimate of the unnormalized KL divergence
     described for variable z.

--- a/probtorch/stochastic.py
+++ b/probtorch/stochastic.py
@@ -341,8 +341,8 @@ class Trace(MutableMapping):
             if not isinstance(node, RandomVariable) or node.observed:
                 yield name
 
-    def log_joint(self, sample_dim=None, sample_dims=None, batch_dim=None, nodes=None,
-                  reparameterized=True):
+    def log_joint(self, sample_dims=None, batch_dim=None, nodes=None,
+                  reparameterized=True, sample_dim=None):
         """Returns the log joint probability, optionally for a subset of nodes.
 
         Arguments:
@@ -454,7 +454,7 @@ def _autogen_trace_methods():
         return _re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
     for name, obj in _inspect.getmembers(_distributions):
-        if hasattr(obj, "__bases__") and issubclass(obj, _distributions.Distribution) and (obj.has_rsample == True):
+        if hasattr(obj, "__bases__") and issubclass(obj, _distributions.Distribution) and obj.has_rsample:
             f_name = camel_to_snake(name).lower()
             doc = """Generates a random variable of type torch.distributions.%s""" % name
             try:

--- a/probtorch/stochastic.py
+++ b/probtorch/stochastic.py
@@ -1,4 +1,5 @@
-from collections import OrderedDict, MutableMapping
+from collections import OrderedDict
+from collections.abc import MutableMapping
 from .util import batch_sum, partial_sum, log_mean_exp
 import abc
 from enum import Enum

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -9,7 +9,7 @@ import math
 
 class TestLogBatchMarginal(TestCase):
     def test_normal(self):
-        N = 100 # Number of training data
+        N = 100  # Number of training data
         S = 3  # sample size
         B = 5  # batch size
         D = 10  # hidden dim
@@ -42,18 +42,17 @@ class TestLogBatchMarginal(TestCase):
                     log_probs1[b1, b2, s] = d1.log_prob(value1[s, b1])
                     log_probs2[b1, b2, s] = d2.log_prob(value2[s, b1])
 
-
         log_sum_1 = log_probs1.sum(3)
         log_sum_2 = log_probs2.sum(3)
 
-        log_joint_2 = log_sum_1 +  log_sum_2
+        log_joint_2 = log_sum_1 + log_sum_2
         log_joint_2[range(B), range(B)] -= math.log(bias)
         log_joint_2 = log_mean_exp(log_joint_2, 1).transpose(0, 1)
 
         log_sum_1[range(B), range(B)] -= math.log(bias)
         log_sum_2[range(B), range(B)] -= math.log(bias)
-        log_mar_z1 = log_mean_exp(log_sum_1, 1).transpose(0, 1) 
-        log_mar_z2 = log_mean_exp(log_sum_2, 1).transpose(0, 1) 
+        log_mar_z1 = log_mean_exp(log_sum_1, 1).transpose(0, 1)
+        log_mar_z2 = log_mean_exp(log_sum_2, 1).transpose(0, 1)
         log_mar_2 = log_mar_z1 + log_mar_z2
 
         log_probs1[range(B), range(B)] -= math.log(bias)

--- a/test/test_stochastic.py
+++ b/test/test_stochastic.py
@@ -3,7 +3,7 @@ from torch.autograd import Variable
 import probtorch
 from torch.distributions import Normal
 from probtorch.util import log_mean_exp
-from common import TestCase, run_tests
+from .common import TestCase, run_tests
 import math
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,7 @@
 import torch
 from random import randint, sample
 from torch.autograd import Variable
-from common import TestCase, run_tests
+from .common import TestCase, run_tests
 from probtorch import util
 
 zero = Variable(torch.Tensor([0.0]))


### PR DESCRIPTION
because backwards compatibility is a thing. But seriously, having only `sample_dims` for one method and `sample_dim` creates confusion in namespace. I agree that `sample_dims` is semantically correct where it's used and we should permit multiple sample dims (and use `sample_dims`) everywhere. In the meantime, let's allow for `sample_dim` (with a deprecation warning). 